### PR TITLE
Updates readme, adds license, restores wp script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-
-
 # Temporary build-tools artifacts to be ignored
 .go/
 bin/
@@ -10,3 +8,5 @@ darwin
 .dockerfile
 VERSION.txt
 .docker_image
+# These are not artifacts that should be ignored
+!files/usr/bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 DRUD Technology, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,13 @@ include build-tools/makefile_components/base_push.mak
 
 test: containertest gitsynctest
 
+# The exec method used here is a workaround for incorrect 129 exit code; pending fix: https://github.com/moby/moby/issues/19699
 containertest: build gitsynctest container
 	@docker stop nginx-php-fpm-test 2>/dev/null || true
 	@docker rm nginx-php-fpm-test 2>/dev/null || true
 	docker run --detach -p 1080:80 --name nginx-php-fpm-test $$(awk '{print $$1}' .docker_image)
+	docker exec -it nginx-php-fpm-test bash -ic "drush --version; (exit \$$?)"
+	docker exec -it nginx-php-fpm-test bash -ic "wp --version; (exit \$$?)"
 	sleep 4
 	curl --fail localhost:1080/healthcheck
 	curl --fail localhost:1080/test/phptest.php

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,12 @@ include build-tools/makefile_components/base_push.mak
 
 test: containertest gitsynctest
 
-# The exec method used here is a workaround for incorrect 129 exit code; pending fix: https://github.com/moby/moby/issues/19699
 containertest: build gitsynctest container
 	@docker stop nginx-php-fpm-test 2>/dev/null || true
 	@docker rm nginx-php-fpm-test 2>/dev/null || true
+	docker run -it  --rm  $$(awk '{print $$1}' .docker_image) drush --version
+	docker run -it  --rm  $$(awk '{print $$1}' .docker_image) wp --version
 	docker run --detach -p 1080:80 --name nginx-php-fpm-test $$(awk '{print $$1}' .docker_image)
-	docker exec -it nginx-php-fpm-test bash -ic "drush --version; (exit \$$?)"
-	docker exec -it nginx-php-fpm-test bash -ic "wp --version; (exit \$$?)"
 	sleep 4
 	curl --fail localhost:1080/healthcheck
 	curl --fail localhost:1080/test/phptest.php

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ This is a Dockerfile to build a container image for NGINX and PHP in FPM with pr
 
 ## Versions
 
-This repo currently provides images to use either PHP 7 or PHP 5.6. 
-
-The PHP 5.6 version is alpine-based and originally forked from [ngineered/nginx-php-fpm](https://github.com/ngineered/nginx-php-fpm)
-
-The PHP 7 version is based on our [PHP7 container](https://github.com/drud/docker.php7) which is based on [minideb](https://github.com/bitnami/minideb)
+This project currently provides images to use PHP 7.0.x. It uses our [PHP7 container](https://github.com/drud/docker.php7) as upstream, which is based on [minideb](https://github.com/bitnami/minideb)
 
 ## Building and pushing to dockerhub
 
@@ -34,13 +30,6 @@ make clean
 
 ## Running
 To simply run the container:
-
-PHP5.6 version:
 ```
-sudo docker run -d drud/nginx-php-fpm
-```
-
-PHP7 version:
-```
-sudo docker run -d drud/nginx-php-fpm7
+docker run -d drud/nginx-php-fpm7
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,14 @@
-machine:
-    services:
-        - docker
+version: 2
+executorType: machine
+stages:
+  build:
+    workDir: ~/docker.nginx-php-fpm
+    steps:
+      - checkout
 
-dependencies:
-    pre:
-        - make linux
+      - run: make container
 
-test:
-    override:
-        - make test
+      - run:
+          shell: /bin/bash
+          command: make test
+          name: make test

--- a/files/usr/bin/wp
+++ b/files/usr/bin/wp
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+##
+# WP-cli wrapper: Append path automatically so that user doesn't have to
+##
+if [ "$(whoami)" = "root" ]; then
+
+  # Gather all arguments because string interpolation doesn't work for $@
+  args=""
+  for i in "$@"; do
+      args="$args \"$i\""
+  done
+
+  /usr/bin/wp-cli "$@" --path=$WP_CORE --allow-root
+else
+  /usr/bin/wp-cli "$@" --path=$WP_CORE
+fi


### PR DESCRIPTION
## The Problems:
- README referenced PHP5.6, which has been removed
- LICENSE did not exist
- We had a wrapper script for the wp-cli which was inadvertently removed with php5.6. I believe this was due to the bin/ rule in .gitignore affecting files we have committed to files/usr/bin/

## The Fixes:
- Updated README
- Added LICENSE
- Restored missing script and added exclusion to .gitignore so it can be tracked.

## The Test:
Previously, `wp` would not be a recognized command in the container. It should be again with this PR.

## Automation Overview:
Tests were added to check drush and wp --version commands.

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
We will need to make a new drud/docker.nginx-php-fpm-local release to make the command available in ddev usage again.
