### PR TITLE
return access log to its own file

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -45,4 +45,6 @@ RUN rm /etc/php/7.0/cli/php.ini && \
 
 EXPOSE 80 443
 
+HEALTHCHECK CMD curl --fail http://localhost/healthcheck/ || exit 1
+
 CMD ["/start.sh"]

--- a/files/etc/nginx/sites-available/default.conf
+++ b/files/etc/nginx/sites-available/default.conf
@@ -10,7 +10,7 @@ server {
     # Disable sendfile as per https://docs.vagrantup.com/v2/synced-folders/virtualbox.html
     sendfile off;
     error_log /var/log/nginx/error.log info;
-    access_log /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
 
     location / {
         # First attempt to serve request as file, then


### PR DESCRIPTION
## The Problem:
We currently combine error and access logs, but error logs are more useful and combining causes developers to have to filter out errors from access, the latter creating many log entries.

## The Fix:
This returns access logging to its originally intended access.log file. ddev users will be otherwise instructed via documentation how to reach access logs and others as needed.

I'm additionally adding the health check we introduced to the local variant.

## The Test:
Take a test site, set webimage in your config to `drud/nginx-php-fpm7:log-change`
Run ddev start
Interact with the site, induce an error if possible. You should not see access log entries running "ddev logs", but you should see errors.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
https://github.com/drud/ddev/issues/87#issuecomment-297091699
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
This will require a bump of the local container.
