### PR TITLE
Really upgrade drush version - driven from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UPSTREAM_REPO ?= drud/php7:$(UPSTREAM_PHP_REPO_TAG)
 SRC_DIRS := git-sync
 
 # Optional to docker build
-DOCKER_ARGS = --build-arg DRUSH_VERSION=8.1.8 --build-arg NGINX_VERSION=1.11.8-1~jessie --build-arg WP_CLI_VERSION=1.0.0
+DOCKER_ARGS = --build-arg DRUSH_VERSION=8.1.12 --build-arg NGINX_VERSION=1.11.8-1~jessie --build-arg WP_CLI_VERSION=1.2.1
 
 # VERSION can be set by
   # Default: git tag


### PR DESCRIPTION
## The Problem:

I previously failed. This time I actually ran the container and did `drush version`. I will do that in the future, I promise. 

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

